### PR TITLE
feat: add `N_CORES` variables by default

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -9,3 +9,6 @@ USE_COMPRESSED ?=1
 
 #IOb-SoC L1 Cache
 USE_L1_CACHE ?=0
+
+#Number of Interrupt Cores
+N_CORES ?= 1

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -21,4 +21,7 @@ DEFINE+=$(defmacro)USE_ATOMIC=$(USE_ATOMIC)
 #use L1 iob-cache
 DEFINE+=$(defmacro)USE_L1_CACHE=$(USE_L1_CACHE)
 
+#define number of interrupt cores
+DEFINE+=$(defmacro)N_CORES=$(N_CORES)
+
 endif


### PR DESCRIPTION
- `N_CORES` set to 1 by default
- Add `N_CORES` to `DEFINE` variable list in hardware.mk