### PR TITLE
Update vexriscv according to new py2hwsw version.

### DIFF
--- a/LICENSES/MIT.txt.license
+++ b/LICENSES/MIT.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 IObundle
+
+SPDX-License-Identifier: MIT

--- a/LICENSES/MIT.txt.license
+++ b/LICENSES/MIT.txt.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2024 IObundle
-
-SPDX-License-Identifier: MIT

--- a/iob_vexriscv.py
+++ b/iob_vexriscv.py
@@ -44,7 +44,7 @@ def setup(py_params_dict):
             {
                 "name": "clk_en_rst_s",
                 "descr": "Clock, clock enable and reset",
-                "interface": {"type": "clk_en_rst"},
+                "signals": {"type": "clk_en_rst"},
             },
             {
                 "name": "rst_i",
@@ -60,7 +60,7 @@ def setup(py_params_dict):
             {
                 "name": "i_bus_m",
                 "descr": "iob-picorv32 instruction bus",
-                "interface": {
+                "signals": {
                     "type": "axi",
                     "prefix": "ibus_",
                     "ID_W": "AXI_ID_W",
@@ -73,7 +73,7 @@ def setup(py_params_dict):
             {
                 "name": "d_bus_m",
                 "descr": "iob-picorv32 data bus",
-                "interface": {
+                "signals": {
                     "type": "axi",
                     "prefix": "dbus_",
                     "ID_W": "AXI_ID_W",
@@ -86,7 +86,7 @@ def setup(py_params_dict):
             {
                 "name": "clint_cbus_s",
                 "descr": "CLINT CSRs bus",
-                "interface": {
+                "signals": {
                     "type": "iob",
                     "prefix": "clint_",
                     "ADDR_W": 16 - 2,
@@ -95,7 +95,7 @@ def setup(py_params_dict):
             {
                 "name": "plic_cbus_s",
                 "descr": "PLIC CSRs bus",
-                "interface": {
+                "signals": {
                     "type": "iob",
                     "prefix": "plic_",
                     "ADDR_W": 22 - 2,
@@ -142,7 +142,7 @@ def setup(py_params_dict):
             {
                 "name": "clint_cbus_axil",
                 "descr": "CLINT CSRs bus",
-                "interface": {
+                "signals": {
                     "type": "axil",
                     "prefix": "clint_",
                     "ADDR_W": 16 - 2,
@@ -152,7 +152,7 @@ def setup(py_params_dict):
             {
                 "name": "plic_cbus_axil",
                 "descr": "PLIC CSRs bus",
-                "interface": {
+                "signals": {
                     "type": "axil",
                     "prefix": "plic_",
                     "ADDR_W": 22 - 2,

--- a/iob_vexriscv.py
+++ b/iob_vexriscv.py
@@ -162,7 +162,7 @@ def setup(py_params_dict):
         ],
         "blocks": [
             {
-                "core_name": "iob2axil",
+                "core_name": "iob_iob2axil",
                 "instance_name": "clint_iob2axil",
                 "instance_description": "Convert IOb to AXI lite for CLINT",
                 "parameters": {
@@ -175,7 +175,7 @@ def setup(py_params_dict):
                 },
             },
             {
-                "core_name": "iob2axil",
+                "core_name": "iob_iob2axil",
                 "instance_name": "plic_iob2axil",
                 "instance_description": "Convert IOb to AXI lite for PLIC",
                 "parameters": {

--- a/iob_vexriscv.py
+++ b/iob_vexriscv.py
@@ -44,7 +44,7 @@ def setup(py_params_dict):
             {
                 "name": "clk_en_rst_s",
                 "descr": "Clock, clock enable and reset",
-                "interface": {"type": "clk_en_rst", "subtype": "slave"},
+                "interface": {"type": "clk_en_rst"},
             },
             {
                 "name": "rst_i",
@@ -62,7 +62,6 @@ def setup(py_params_dict):
                 "descr": "iob-picorv32 instruction bus",
                 "interface": {
                     "type": "axi",
-                    "subtype": "master",
                     "port_prefix": "ibus_",
                     "ID_W": "AXI_ID_W",
                     "ADDR_W": "AXI_ADDR_W",
@@ -76,7 +75,6 @@ def setup(py_params_dict):
                 "descr": "iob-picorv32 data bus",
                 "interface": {
                     "type": "axi",
-                    "subtype": "master",
                     "port_prefix": "dbus_",
                     "ID_W": "AXI_ID_W",
                     "ADDR_W": "AXI_ADDR_W",
@@ -90,7 +88,6 @@ def setup(py_params_dict):
                 "descr": "CLINT CSRs bus",
                 "interface": {
                     "type": "iob",
-                    "subtype": "slave",
                     "port_prefix": "clint_",
                     "ADDR_W": "16",
                 },
@@ -100,7 +97,6 @@ def setup(py_params_dict):
                 "descr": "PLIC CSRs bus",
                 "interface": {
                     "type": "iob",
-                    "subtype": "slave",
                     "port_prefix": "plic_",
                     "ADDR_W": "22",
                 },
@@ -148,7 +144,6 @@ def setup(py_params_dict):
                 "descr": "CLINT CSRs bus",
                 "interface": {
                     "type": "axil",
-                    "subtype": "slave",
                     "wire_prefix": "clint_",
                     "ADDR_W": "16",
                     "DATA_W": "AXI_DATA_W",
@@ -159,7 +154,6 @@ def setup(py_params_dict):
                 "descr": "PLIC CSRs bus",
                 "interface": {
                     "type": "axil",
-                    "subtype": "slave",
                     "wire_prefix": "plic_",
                     "ADDR_W": "22",
                     "DATA_W": "AXI_DATA_W",


### PR DESCRIPTION
Rename 'interface' to 'signals'; Rename blocks to include new `iob_` prefix.
Supported by py2hwsw version from PR https://github.com/IObundle/py2hwsw/pull/76